### PR TITLE
feat: コンテンツ詳細のUIをざっくり作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.0",
         "@radix-ui/react-scroll-area": "^1.1.0",
+        "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -583,6 +584,29 @@
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.0.tgz",
+      "integrity": "sha512-3uBAs+egzvJBDZAzvb/n4NxxOYpnspmWxO2u5NbZ8Y6FM/NdrGSF9bop3Cf6F6C71z1rTSn8KV0Fo2ZVd79lGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-scroll-area": "^1.1.0",
+    "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/app/contents/[id]/page.tsx
+++ b/src/app/contents/[id]/page.tsx
@@ -1,0 +1,22 @@
+import Header from "@/components/Header";
+import ContentCard from "@/app/contents/_components/ContentCard";
+
+const ContentDetail = ({ params }: { params: { id: string } }) => {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <div className="flex flex-1">
+        <main className="flex-1 p-6">
+          <ContentCard id={params.id} />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export async function generateStaticParams() {
+  // 動的なパラメータを生成するロジックをここに実装
+  return [{ id: "1" }, { id: "2" }]; // 例：id 1と2のページを生成
+}
+
+export default ContentDetail;

--- a/src/app/contents/[id]/page.tsx
+++ b/src/app/contents/[id]/page.tsx
@@ -1,15 +1,9 @@
-import Header from "@/components/Header";
-import ContentCard from "@/app/contents/_components/ContentCard";
+import Article from "@/app/contents/_components/Article";
 
 const ContentDetail = ({ params }: { params: { id: string } }) => {
   return (
-    <div className="flex flex-col min-h-screen">
-      <Header />
-      <div className="flex flex-1">
-        <main className="flex-1 p-6">
-          <ContentCard id={params.id} />
-        </main>
-      </div>
+    <div className="max-w-[750px] mx-auto">
+      <Article />
     </div>
   );
 };

--- a/src/app/contents/[id]/page.tsx
+++ b/src/app/contents/[id]/page.tsx
@@ -1,16 +1,22 @@
 import Article from "@/app/contents/_components/Article";
+import type { Content } from "../_components/Article";
 
 const ContentDetail = ({ params }: { params: { id: string } }) => {
-  return (
-    <div className="max-w-[750px] mx-auto">
-      <Article />
-    </div>
-  );
+  const content: Content = getContent(params.id);
+  return <Article content={content} />;
 };
 
-export async function generateStaticParams() {
-  // 動的なパラメータを生成するロジックをここに実装
-  return [{ id: "1" }, { id: "2" }]; // 例：id 1と2のページを生成
+// mock
+function getContent(id: string): Content {
+  return {
+    title: `タイトル ${id}`,
+    body: `コンテンツ ${id}の詳細な説明です。このコンテンツは、さまざまな情報を提供し、読者にとって有益な内容を含んでいます。さらに、関連するトピックや事例を交えながら、深く掘り下げていきます。最終的には、読者がこの情報を活用できるように、具体的なアクションプランや提案も含めています。`,
+    author: {
+      name: "山田太郎",
+      image: "https://example.com/avatar.jpg",
+    },
+    publishedAt: "2023年4月1日",
+  };
 }
 
 export default ContentDetail;

--- a/src/app/contents/[id]/page.tsx
+++ b/src/app/contents/[id]/page.tsx
@@ -16,6 +16,7 @@ function getContent(id: string): Content {
       image: "https://example.com/avatar.jpg",
     },
     publishedAt: "2023年4月1日",
+    type: "showNote",
   };
 }
 

--- a/src/app/contents/_components/Article.tsx
+++ b/src/app/contents/_components/Article.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
+import { Badge } from "@/components/ui/badge"; // 新しいインポート
 
 export interface Content {
   title: string;
@@ -10,13 +11,32 @@ export interface Content {
     image: string;
   };
   publishedAt: string;
+  type: "showNote" | "annotation" | "review";
 }
 
+const getContentTypeLabel = (type: Content["type"]) => {
+  switch (type) {
+    case "showNote":
+      return "まとめ・文字起こし";
+    case "annotation":
+      return "補足・資料";
+    case "review":
+      return "感想・レビュー";
+    default:
+      return "";
+  }
+};
+
 const Article = ({ content }: { content: Content }) => {
+  const typeLabel = getContentTypeLabel(content.type);
+
   return (
     <Card className="max-w-[750px] mx-auto">
       <CardHeader>
-        <CardTitle className="text-3xl font-bold">{content.title}</CardTitle>
+        <div className="flex justify-between items-start">
+          <CardTitle className="text-3xl font-bold">{content.title}</CardTitle>
+          <Badge variant="secondary">{typeLabel}</Badge>
+        </div>
         <div className="flex items-center space-x-4 mt-4">
           <Avatar>
             <AvatarImage src={content.author.image} alt={content.author.name} />

--- a/src/app/contents/_components/Article.tsx
+++ b/src/app/contents/_components/Article.tsx
@@ -1,13 +1,40 @@
-import ContentCard from "./ContentCard";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Separator } from "@/components/ui/separator";
 
-const Article = () => {
+export interface Content {
+  title: string;
+  body: string;
+  author: {
+    name: string;
+    image: string;
+  };
+  publishedAt: string;
+}
+
+const Article = ({ content }: { content: Content }) => {
   return (
-    <article>
-      <header>タイトル</header>
-      <div>
-        <ContentCard id={"1"} />
-      </div>
-    </article>
+    <Card className="max-w-[750px] mx-auto">
+      <CardHeader>
+        <CardTitle className="text-3xl font-bold">{content.title}</CardTitle>
+        <div className="flex items-center space-x-4 mt-4">
+          <Avatar>
+            <AvatarImage src={content.author.image} alt={content.author.name} />
+            <AvatarFallback>{content.author.name[0]}</AvatarFallback>
+          </Avatar>
+          <div>
+            <p className="text-sm font-medium">{content.author.name}</p>
+            <p className="text-sm text-muted-foreground">
+              {content.publishedAt}
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+      <Separator />
+      <CardContent className="pt-6">
+        <div className="prose max-w-none">{content.body}</div>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/src/app/contents/_components/Article.tsx
+++ b/src/app/contents/_components/Article.tsx
@@ -1,0 +1,14 @@
+import ContentCard from "./ContentCard";
+
+const Article = () => {
+  return (
+    <article>
+      <header>タイトル</header>
+      <div>
+        <ContentCard id={"1"} />
+      </div>
+    </article>
+  );
+};
+
+export default Article;

--- a/src/app/contents/_components/ContentCard.tsx
+++ b/src/app/contents/_components/ContentCard.tsx
@@ -1,0 +1,26 @@
+import { Card } from "@/components/ui/card";
+
+const ContentCard = async ({ id }: { id: string }) => {
+  const content = await getContent(id);
+  return (
+    <Card className="h-40 p-4">
+      <div>{content.title}</div>
+      <div>{content.description}</div>
+    </Card>
+  );
+};
+
+const getContent = async (id: string) => {
+  // const res = await fetch(`http://localhost:3000/api/contents/${id}`);
+  // const data = await res.json();
+
+  // 仮のデータ
+  const data = {
+    id: id,
+    title: `ID: ${id}のタイトル`,
+    description: `ID: ${id}の説明。<br>改行ありである程度長い文章を記載します。<br>改行ありである程度長い文章を記載します。<br>改行ありである程度長い文章を記載します。`,
+  };
+  return data;
+};
+
+export default ContentCard;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import Header from "@/components/Header";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,7 +17,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <div className="flex flex-col min-h-screen">
+          <Header />
+          {children}
+        </div>
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,21 +4,18 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 
 export default function Home() {
   return (
-    <div className="flex flex-col min-h-screen">
-      <Header />
-      <div className="flex flex-1">
-        <main className="flex-1 p-6">
-          <ScrollArea className="h-[calc(100vh-100px)]">
-            <div className="bg-card rounded-lg shadow p-4">
-              {Array.from({ length: 10 }, (_, index) => (
-                <div className="mb-4" key={index}>
-                  <Content />
-                </div>
-              ))}
-            </div>
-          </ScrollArea>
-        </main>
-      </div>
+    <div className="flex flex-1">
+      <main className="flex-1 p-6">
+        <ScrollArea className="h-[calc(100vh-100px)]">
+          <div className="bg-card rounded-lg shadow p-4">
+            {Array.from({ length: 10 }, (_, index) => (
+              <div className="mb-4" key={index}>
+                <Content />
+              </div>
+            ))}
+          </div>
+        </ScrollArea>
+      </main>
     </div>
   );
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import Link from "next/link";
 
 const Header = () => {
   return (
     <header className="w-full h-16 flex items-center justify-between px-4">
-      <h1 className="text-2xl font-bold">Podcast Hub</h1>
+      <Link href={"/"}>
+        <h1 className="text-2xl font-bold">Podcast Hub</h1>
+      </Link>
 
       <div className="flex items-center space-x-2">
         <Avatar>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/src/features/contents/components/Content.tsx
+++ b/src/features/contents/components/Content.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { Card } from "@/components/ui/card";
-import { CardContent } from "@/components/ui/card";
-import { CardFooter } from "@/components/ui/card";
 import ContentHeader from "./ContentHeader";
 import ContentBody from "./ContentBody";
 import ContentFooter from "./ContentFooter";

--- a/src/features/contents/components/ContentBody.tsx
+++ b/src/features/contents/components/ContentBody.tsx
@@ -1,11 +1,18 @@
 import React from "react";
 import { CardContent } from "@/components/ui/card";
+import Link from "next/link";
 
 const tmp_long_text =
   "ここにボディの内容が入ります。ここにボディの内容が入ります。<br />ここにボディの内容が入ります。ここにボディの内容が入ります。<br />ここにボディの内容が入ります。";
 
 const ContentBody = () => {
-  return <CardContent dangerouslySetInnerHTML={{ __html: tmp_long_text }} />;
+  return (
+    <CardContent>
+      <Link href={"/contents/1"}>
+        <div dangerouslySetInnerHTML={{ __html: tmp_long_text }} />
+      </Link>
+    </CardContent>
+  );
 };
 
 export default ContentBody;


### PR DESCRIPTION
## 依存

- #7 

## 変更

- コンテンツ詳細のUIを追加
- コンテンツ typeによる出し分けを考慮
- HeaderのLayout変更なども少し行った