### PR TITLE
feat: Podcastエピソード詳細 UIと導線の作成

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,16 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  // TODO: Mock用に外部hostの画像へのアクセス許可をしている。supabase導入後に削除する
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "i.scdn.co",
+        port: "",
+        pathname: "/image/**",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/src/app/contents/[id]/page.tsx
+++ b/src/app/contents/[id]/page.tsx
@@ -17,6 +17,10 @@ function getContent(id: string): Content {
     },
     publishedAt: "2023年4月1日",
     type: "showNote",
+    podcastEpisode: {
+      id: "1",
+      title: "Podcastエピソードのタイトル",
+    },
   };
 }
 

--- a/src/app/contents/[id]/page.tsx
+++ b/src/app/contents/[id]/page.tsx
@@ -1,5 +1,5 @@
 import Article from "@/app/contents/_components/Article";
-import type { Content } from "../_components/Article";
+import type { Content } from "@/lib/types";
 
 const ContentDetail = ({ params }: { params: { id: string } }) => {
   const content: Content = getContent(params.id);
@@ -20,6 +20,9 @@ function getContent(id: string): Content {
     podcastEpisode: {
       id: "1",
       title: "Podcastエピソードのタイトル",
+      description: "Podcastエピソードの詳細な説明です。",
+      imageUrl:
+        "https://i.scdn.co/image/ab67656300005f1fb412cc05140e5eedc61ac87d",
     },
   };
 }

--- a/src/app/contents/[id]/page.tsx
+++ b/src/app/contents/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Article from "@/app/contents/_components/Article";
 import type { Content } from "@/lib/types";
+import { generateMockContent } from "@/lib/mock";
 
 const ContentDetail = ({ params }: { params: { id: string } }) => {
   const content: Content = getContent(params.id);
@@ -8,23 +9,7 @@ const ContentDetail = ({ params }: { params: { id: string } }) => {
 
 // mock
 function getContent(id: string): Content {
-  return {
-    title: `タイトル ${id}`,
-    body: `コンテンツ ${id}の詳細な説明です。このコンテンツは、さまざまな情報を提供し、読者にとって有益な内容を含んでいます。さらに、関連するトピックや事例を交えながら、深く掘り下げていきます。最終的には、読者がこの情報を活用できるように、具体的なアクションプランや提案も含めています。`,
-    author: {
-      name: "山田太郎",
-      image: "https://example.com/avatar.jpg",
-    },
-    publishedAt: "2023年4月1日",
-    type: "showNote",
-    podcastEpisode: {
-      id: "1",
-      title: "Podcastエピソードのタイトル",
-      description: "Podcastエピソードの詳細な説明です。",
-      imageUrl:
-        "https://i.scdn.co/image/ab67656300005f1fb412cc05140e5eedc61ac87d",
-    },
-  };
+  return generateMockContent(id);
 }
 
 export default ContentDetail;

--- a/src/app/contents/_components/Article.tsx
+++ b/src/app/contents/_components/Article.tsx
@@ -4,23 +4,7 @@ import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 import LikeButton from "./LikeButton";
 import Link from "next/link";
-
-export interface Content {
-  title: string;
-  body: string;
-  author: {
-    name: string;
-    image: string;
-  };
-  publishedAt: string;
-  type: "showNote" | "annotation" | "review";
-  podcastEpisode: PodcastEpisode;
-}
-
-interface PodcastEpisode {
-  title: string;
-  id: string;
-}
+import type { Content } from "@/lib/types";
 
 const getContentTypeLabel = (type: Content["type"]) => {
   switch (type) {

--- a/src/app/contents/_components/Article.tsx
+++ b/src/app/contents/_components/Article.tsx
@@ -3,6 +3,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 import LikeButton from "./LikeButton";
+import Link from "next/link";
 
 export interface Content {
   title: string;
@@ -13,6 +14,12 @@ export interface Content {
   };
   publishedAt: string;
   type: "showNote" | "annotation" | "review";
+  podcastEpisode: PodcastEpisode;
+}
+
+interface PodcastEpisode {
+  title: string;
+  id: string;
 }
 
 const getContentTypeLabel = (type: Content["type"]) => {
@@ -51,6 +58,16 @@ const Article = ({ content }: { content: Content }) => {
           </div>
         </div>
       </CardHeader>
+      <Separator />
+      <div className="px-6 py-4 bg-muted">
+        <p className="text-sm font-medium mb-1">引用元Podcastエピソード：</p>
+        <Link
+          href={`/episodes/${content.podcastEpisode.id}`}
+          className="text-primary hover:underline"
+        >
+          {content.podcastEpisode.title}
+        </Link>
+      </div>
       <Separator />
       <CardContent className="pt-6">
         <div className="prose max-w-none">{content.body}</div>

--- a/src/app/episodes/[id]/page.tsx
+++ b/src/app/episodes/[id]/page.tsx
@@ -1,0 +1,20 @@
+import EpisodeDetail from "../_components/EpisodeDetail";
+import type { PodcastEpisode } from "@/lib/types";
+
+const EpisodePage = ({ params }: { params: { id: string } }) => {
+  const episode: PodcastEpisode = getEpisode(params.id);
+  return <EpisodeDetail episode={episode} />;
+};
+
+// モックデータを生成する関数
+function getEpisode(id: string): PodcastEpisode {
+  return {
+    id,
+    title: `エピソード ${id} のタイトル`,
+    description: `これはエピソード ${id} の詳細な説明です。このポッドキャストエピソードでは、興味深いトピックについて議論し、リスナーに価値ある情報を提供します。`,
+    imageUrl:
+      "https://i.scdn.co/image/ab67656300005f1fb412cc05140e5eedc61ac87d",
+  };
+}
+
+export default EpisodePage;

--- a/src/app/episodes/[id]/page.tsx
+++ b/src/app/episodes/[id]/page.tsx
@@ -1,5 +1,6 @@
 import EpisodeDetail from "../_components/EpisodeDetail";
 import type { PodcastEpisode } from "@/lib/types";
+import { generateMockEpisode } from "@/lib/mock";
 
 const EpisodePage = ({ params }: { params: { id: string } }) => {
   const episode: PodcastEpisode = getEpisode(params.id);
@@ -8,13 +9,7 @@ const EpisodePage = ({ params }: { params: { id: string } }) => {
 
 // モックデータを生成する関数
 function getEpisode(id: string): PodcastEpisode {
-  return {
-    id,
-    title: `エピソード ${id} のタイトル`,
-    description: `これはエピソード ${id} の詳細な説明です。このポッドキャストエピソードでは、興味深いトピックについて議論し、リスナーに価値ある情報を提供します。`,
-    imageUrl:
-      "https://i.scdn.co/image/ab67656300005f1fb412cc05140e5eedc61ac87d",
-  };
+  return generateMockEpisode(id);
 }
 
 export default EpisodePage;

--- a/src/app/episodes/_components/EpisodeDetail.tsx
+++ b/src/app/episodes/_components/EpisodeDetail.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import type { PodcastEpisode } from "@/lib/types";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Separator } from "@/components/ui/separator";
+import Image from "next/image";
+
+interface EpisodeDetailProps {
+  episode: PodcastEpisode;
+}
+
+const EpisodeDetail: React.FC<EpisodeDetailProps> = ({ episode }) => {
+  return (
+    <Card className="max-w-[750px] mx-auto">
+      <CardHeader>
+        <div className="flex items-center space-x-4">
+          <Image
+            src={episode.imageUrl}
+            alt={episode.title}
+            width={80}
+            height={80}
+            className="rounded-lg"
+          />
+          <div>
+            <CardTitle className="text-3xl font-bold">
+              {episode.title}
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              エピソードID: {episode.id}
+            </p>
+          </div>
+        </div>
+      </CardHeader>
+      <Separator />
+      <CardContent className="pt-6">
+        <div className="prose max-w-none">{episode.description}</div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default EpisodeDetail;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import Header from "@/components/Header";
 import Content from "@/features/contents/components/Content";
 import { ScrollArea } from "@/components/ui/scroll-area";
 

--- a/src/lib/mock.ts
+++ b/src/lib/mock.ts
@@ -1,0 +1,31 @@
+import type { Content, PodcastEpisode } from "@/lib/types";
+
+export function generateMockContent(id: string): Content {
+  return {
+    title: `タイトル ${id}`,
+    body: `コンテンツ ${id}の詳細な説明です。このコンテンツは、さまざまな情報を提供し、読者にとって有益な内容を含んでいます。さらに、関連するトピックや事例を交えながら、深く掘り下げていきます。最終的には、読者がこの情報を活用できるように、具体的なアクションプランや提案も含めています。`,
+    author: {
+      name: "山田太郎",
+      image: "https://example.com/avatar.jpg",
+    },
+    publishedAt: "2023年4月1日",
+    type: "showNote",
+    podcastEpisode: {
+      id: "1",
+      title: "Podcastエピソードのタイトル",
+      description: "Podcastエピソードの詳細な説明です。",
+      imageUrl:
+        "https://i.scdn.co/image/ab67656300005f1fb412cc05140e5eedc61ac87d",
+    },
+  };
+}
+
+export function generateMockEpisode(id: string): PodcastEpisode {
+  return {
+    id,
+    title: `エピソード ${id} のタイトル`,
+    description: `これはエピソード ${id} の詳細な説明です。このポッドキャストエピソードでは、興味深いトピックについて議論し、リスナーに価値ある情報を提供します。`,
+    imageUrl:
+      "https://i.scdn.co/image/ab67656300005f1fb412cc05140e5eedc61ac87d",
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,18 @@
+export interface Content {
+  title: string;
+  body: string;
+  author: {
+    name: string;
+    image: string;
+  };
+  publishedAt: string;
+  type: "showNote" | "annotation" | "review";
+  podcastEpisode: PodcastEpisode;
+}
+
+export interface PodcastEpisode {
+  id: string;
+  title: string;
+  description: string;
+  imageUrl: string;
+}


### PR DESCRIPTION
## 関連Issue

- #10 
- #9 

## 概要

- Podcastエピソード詳細画面において、UIと導線を作成しました。
- エピソード詳細画面の修正を行い、typesを一旦共通化しました。
- 一時的なデータのmokingを一箇所にまとめました。

