### PR TITLE
Podcastチェンネル詳細 UI作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "tsc": "tsc --noEmit"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.0",

--- a/src/app/channels/[id]/_components/ChannelDetail.tsx
+++ b/src/app/channels/[id]/_components/ChannelDetail.tsx
@@ -1,21 +1,36 @@
 import type { Channel } from "@/lib/types";
-import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import Image from "next/image";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardDescription,
+} from "@/components/ui/card";
 
 interface ChannelDetailsProps {
   channel: Channel;
 }
 
-// WIP: ひとまずの箱
 const ChannelDetail: React.FC<ChannelDetailsProps> = ({ channel }) => {
   return (
-    <div>
-      ChannelDetails
-      <Card>
-        <CardHeader>
+    <Card className="max-w-[750px] mx-auto">
+      <CardHeader>
+        <div className="flex items-center space-x-4">
+          <Image
+            src={channel.imageUrl}
+            alt={channel.name}
+            width={100}
+            height={100}
+            className="rounded-full"
+          />
           <CardTitle>{channel.name}</CardTitle>
-        </CardHeader>
-      </Card>
-    </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <CardDescription>{channel.description}</CardDescription>
+      </CardContent>
+    </Card>
   );
 };
 

--- a/src/app/channels/[id]/_components/ChannelDetail.tsx
+++ b/src/app/channels/[id]/_components/ChannelDetail.tsx
@@ -1,0 +1,22 @@
+import type { Channel } from "@/lib/types";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface ChannelDetailsProps {
+  channel: Channel;
+}
+
+// WIP: ひとまずの箱
+const ChannelDetail: React.FC<ChannelDetailsProps> = ({ channel }) => {
+  return (
+    <div>
+      ChannelDetails
+      <Card>
+        <CardHeader>
+          <CardTitle>{channel.name}</CardTitle>
+        </CardHeader>
+      </Card>
+    </div>
+  );
+};
+
+export default ChannelDetail;

--- a/src/app/channels/[id]/page.tsx
+++ b/src/app/channels/[id]/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import ChannelDetail from "./_components/ChannelDetail";
+import type { Channel } from "@/lib/types";
+import { generateMockChannel } from "@/lib/mock";
+
+export const metadata: Metadata = {
+  title: "チャンネル詳細 - Podcast Hub",
+  description: "Podcastに貢献できる場所",
+};
+
+const ChannelPage = ({ params }: { params: { id: string } }) => {
+  const channel: Channel = getChannel(params.id);
+  return <ChannelDetail channel={channel} />;
+};
+
+function getChannel(id: string): Channel {
+  return generateMockChannel(id);
+}
+
+export default ChannelPage;

--- a/src/app/contents/[id]/page.tsx
+++ b/src/app/contents/[id]/page.tsx
@@ -1,6 +1,12 @@
+import type { Metadata } from "next";
 import Article from "@/app/contents/_components/Article";
 import type { Content } from "@/lib/types";
 import { generateMockContent } from "@/lib/mock";
+
+export const metadata: Metadata = {
+  title: "コンテンツ詳細 - Podcast Hub",
+  description: "Podcastに貢献できる場所",
+};
 
 const ContentDetail = ({ params }: { params: { id: string } }) => {
   const content: Content = getContent(params.id);

--- a/src/app/contents/_components/Article.tsx
+++ b/src/app/contents/_components/Article.tsx
@@ -46,10 +46,10 @@ const Article = ({ content }: { content: Content }) => {
       <div className="px-6 py-4 bg-muted">
         <p className="text-sm font-medium mb-1">引用元Podcastエピソード：</p>
         <Link
-          href={`/episodes/${content.podcastEpisode.id}`}
+          href={`/episodes/${content.episode.id}`}
           className="text-primary hover:underline"
         >
-          {content.podcastEpisode.title}
+          {content.episode.title}
         </Link>
       </div>
       <Separator />

--- a/src/app/episodes/[id]/page.tsx
+++ b/src/app/episodes/[id]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import EpisodeDetail from "../_components/EpisodeDetail";
-import type { PodcastEpisode } from "@/lib/types";
+import type { Episode } from "@/lib/types";
 import { generateMockEpisode } from "@/lib/mock";
 
 export const metadata: Metadata = {
@@ -9,12 +9,12 @@ export const metadata: Metadata = {
 };
 
 const EpisodePage = ({ params }: { params: { id: string } }) => {
-  const episode: PodcastEpisode = getEpisode(params.id);
+  const episode: Episode = getEpisode(params.id);
   return <EpisodeDetail episode={episode} />;
 };
 
 // モックデータを生成する関数
-function getEpisode(id: string): PodcastEpisode {
+function getEpisode(id: string): Episode {
   return generateMockEpisode(id);
 }
 

--- a/src/app/episodes/[id]/page.tsx
+++ b/src/app/episodes/[id]/page.tsx
@@ -1,6 +1,12 @@
+import type { Metadata } from "next";
 import EpisodeDetail from "../_components/EpisodeDetail";
 import type { PodcastEpisode } from "@/lib/types";
 import { generateMockEpisode } from "@/lib/mock";
+
+export const metadata: Metadata = {
+  title: "エピソード詳細 - Podcast Hub",
+  description: "Podcastに貢献できる場所",
+};
 
 const EpisodePage = ({ params }: { params: { id: string } }) => {
   const episode: PodcastEpisode = getEpisode(params.id);

--- a/src/app/episodes/_components/EpisodeDetail.tsx
+++ b/src/app/episodes/_components/EpisodeDetail.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import type { PodcastEpisode } from "@/lib/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
-import Image from "next/image";
+import EpisodeParentChannel from "./EpisodeParentChanel";
 
 interface EpisodeDetailProps {
   episode: PodcastEpisode;
@@ -14,13 +13,6 @@ const EpisodeDetail: React.FC<EpisodeDetailProps> = ({ episode }) => {
     <Card className="max-w-[750px] mx-auto">
       <CardHeader>
         <div className="flex items-center space-x-4">
-          <Image
-            src={episode.imageUrl}
-            alt={episode.title}
-            width={80}
-            height={80}
-            className="rounded-lg"
-          />
           <div>
             <CardTitle className="text-3xl font-bold">
               {episode.title}
@@ -30,6 +22,7 @@ const EpisodeDetail: React.FC<EpisodeDetailProps> = ({ episode }) => {
             </p>
           </div>
         </div>
+        <EpisodeParentChannel channel={episode.channel} />
       </CardHeader>
       <Separator />
       <CardContent className="pt-6">

--- a/src/app/episodes/_components/EpisodeDetail.tsx
+++ b/src/app/episodes/_components/EpisodeDetail.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import type { PodcastEpisode } from "@/lib/types";
+import type { Episode } from "@/lib/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import EpisodeParentChannel from "./EpisodeParentChanel";
 
 interface EpisodeDetailProps {
-  episode: PodcastEpisode;
+  episode: Episode;
 }
 
 const EpisodeDetail: React.FC<EpisodeDetailProps> = ({ episode }) => {

--- a/src/app/episodes/_components/EpisodeParentChanel.tsx
+++ b/src/app/episodes/_components/EpisodeParentChanel.tsx
@@ -1,0 +1,25 @@
+import Image from "next/image";
+import { CardTitle } from "@/components/ui/card";
+import type { Channel } from "@/lib/types";
+import Link from "next/link";
+
+const EpisodeParentChannel = ({ channel }: { channel: Channel }) => {
+  return (
+    <Link href={`/channels/${channel.id}`}>
+      <div className="flex items-center space-x-4 mt-4">
+        <Image
+          src={channel.imageUrl}
+          alt={channel.name}
+          width={40}
+          height={40}
+          className="rounded-full"
+        />
+        <div>
+          <CardTitle className="text-lg font-normal">{channel.name}</CardTitle>
+        </div>
+      </div>
+    </Link>
+  );
+};
+
+export default EpisodeParentChannel;

--- a/src/lib/mock.ts
+++ b/src/lib/mock.ts
@@ -1,4 +1,4 @@
-import type { Content, PodcastEpisode, Channel } from "@/lib/types";
+import type { Content, Episode, Channel } from "@/lib/types";
 
 export function generateMockContent(id: string): Content {
   return {
@@ -10,11 +10,11 @@ export function generateMockContent(id: string): Content {
     },
     publishedAt: "2023年4月1日",
     type: "showNote",
-    podcastEpisode: generateMockEpisode("1"),
+    episode: generateMockEpisode("1"),
   };
 }
 
-export function generateMockEpisode(id: string): PodcastEpisode {
+export function generateMockEpisode(id: string): Episode {
   return {
     id,
     title: `エピソード ${id} のタイトル`,

--- a/src/lib/mock.ts
+++ b/src/lib/mock.ts
@@ -1,4 +1,4 @@
-import type { Content, PodcastEpisode } from "@/lib/types";
+import type { Content, PodcastEpisode, Channel } from "@/lib/types";
 
 export function generateMockContent(id: string): Content {
   return {
@@ -10,13 +10,7 @@ export function generateMockContent(id: string): Content {
     },
     publishedAt: "2023年4月1日",
     type: "showNote",
-    podcastEpisode: {
-      id: "1",
-      title: "Podcastエピソードのタイトル",
-      description: "Podcastエピソードの詳細な説明です。",
-      imageUrl:
-        "https://i.scdn.co/image/ab67656300005f1fb412cc05140e5eedc61ac87d",
-    },
+    podcastEpisode: generateMockEpisode("1"),
   };
 }
 
@@ -25,6 +19,17 @@ export function generateMockEpisode(id: string): PodcastEpisode {
     id,
     title: `エピソード ${id} のタイトル`,
     description: `これはエピソード ${id} の詳細な説明です。このポッドキャストエピソードでは、興味深いトピックについて議論し、リスナーに価値ある情報を提供します。`,
+    imageUrl:
+      "https://i.scdn.co/image/ab67656300005f1fb412cc05140e5eedc61ac87d",
+    channel: generateMockChannel("1"),
+  };
+}
+
+export function generateMockChannel(id: string): Channel {
+  return {
+    id,
+    name: `チャンネル ${id} のタイトル`,
+    description: `これはチャンネル ${id} の詳細な説明です。このポッドキャストチャンネルでは、興味深いトピックについて議論し、リスナーに価値ある情報を提供します。`,
     imageUrl:
       "https://i.scdn.co/image/ab67656300005f1fb412cc05140e5eedc61ac87d",
   };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,10 +7,10 @@ export interface Content {
   };
   publishedAt: string;
   type: "showNote" | "annotation" | "review";
-  podcastEpisode: PodcastEpisode;
+  episode: Episode;
 }
 
-export interface PodcastEpisode {
+export interface Episode {
   id: string;
   title: string;
   description: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,5 +14,13 @@ export interface PodcastEpisode {
   id: string;
   title: string;
   description: string;
+  imageUrl: string; // エピソードの画像は不要かも？
+  channel: Channel;
+}
+
+export interface Channel {
+  id: string;
+  name: string;
+  description: string;
   imageUrl: string;
 }


### PR DESCRIPTION
- #12 

## 実装内容

- チャンネル詳細ページのUIを作成しました
- チャンネル詳細ページにmeta情報を追加しました
- チャンネル詳細ページの導線と箱を作成しました
- チャンネル詳細ページのUI作成に伴い、PodcastEpisodeをEpisodeに変更しました


